### PR TITLE
Add helper script for launching UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,8 @@ This repository is intended for experimentation with NVIDIA Blackwell GPUs with 
 ## Quick start
 
 ```bash
-# Install dependencies from NVIDIA's PyPI
-./scripts/setup.sh
-
-# Run the Gradio interface
-python app.py
+# Install dependencies and launch the Gradio interface
+./start_ui.sh
 ```
 
 ### Quantize a vision language model

--- a/start_ui.sh
+++ b/start_ui.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Simple helper to install dependencies and launch the Gradio UI
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Install dependencies
+if [ -f "$SCRIPT_DIR/scripts/setup.sh" ]; then
+    bash "$SCRIPT_DIR/scripts/setup.sh"
+fi
+
+# Launch the UI
+python "$SCRIPT_DIR/app.py" "$@"


### PR DESCRIPTION
## Summary
- add `start_ui.sh` helper script to install deps & launch Gradio interface
- update quick start docs to use `./start_ui.sh`

## Testing
- `./scripts/setup.sh` *(fails: Tunnel connection failed)

------
https://chatgpt.com/codex/tasks/task_e_687912b4ca70832aaef783fd538396c3