### PR TITLE
Build xformers from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,11 @@ python quantize_vlm.py --model-id my/model --token <HF_TOKEN> --method unsloth
 ## NVIDIA AI Workbench
 
 The `workbench-project.yml` file configures this repo as an NVIDIA AI Workbench project so it can be launched in a containerized environment with GPU access.
+
+## Building xformers from source
+
+`xformers` is required by some quantization tools but pre-built wheels are not
+always available for every combination of CUDA and PyTorch. The `scripts/setup.sh`
+script automatically clones the official repository with all submodules and
+compiles it against the version of PyTorch installed from `requirements.txt`.
+When using `start_ui.sh` or the Docker image, this step runs automatically.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,3 +1,16 @@
 #!/bin/bash
 set -e
+
+# Install base Python dependencies
 pip install --no-cache-dir -r requirements.txt --extra-index-url https://pypi.nvidia.com/
+
+# Build xformers from source if it isn't already installed. This avoids issues
+# with pre-built wheels not matching the current CUDA or PyTorch versions.
+if ! python -c "import xformers" >/dev/null 2>&1; then
+    TEMP_DIR=$(mktemp -d)
+    git clone --recursive https://github.com/facebookresearch/xformers.git "$TEMP_DIR/xformers"
+    pushd "$TEMP_DIR/xformers"
+    pip install --no-cache-dir -v -e .
+    popd
+    rm -rf "$TEMP_DIR"
+fi


### PR DESCRIPTION
## Summary
- compile xformers directly from the GitHub repo to avoid wheel issues
- document xformers compilation in the README

## Testing
- `python -m py_compile app.py quantize_vlm.py`
- `bash -n scripts/setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_68791e28aba0832aa2b9c743ce737c7b