### PR TITLE
Handle SentencePiece tokenizer errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,19 @@ always available for every combination of CUDA and PyTorch. The `scripts/setup.s
 script automatically clones the official repository with all submodules and
 compiles it against the version of PyTorch installed from `requirements.txt`.
 When using `start_ui.sh` or the Docker image, this step runs automatically.
+
+## Troubleshooting
+
+If you encounter an error similar to:
+
+```
+ValueError: Converting from SentencePiece and Tiktoken failed, if a converter for SentencePiece is available, provide a model path with a SentencePiece tokenizer.model file. Currently available slow->fast converters: [...]
+```
+
+load the tokenizer with `use_fast=False`:
+
+```python
+tokenizer = AutoTokenizer.from_pretrained("<model>", use_fast=False)
+```
+
+The Gradio app has been updated to do this automatically.

--- a/app.py
+++ b/app.py
@@ -51,7 +51,7 @@ def optimize(model_id, token, progress=gr.Progress()):
         model_path = download_model(model_id, token)
         
         progress(0.3, desc="⚡ Loading model and tokenizer...")
-        tokenizer = AutoTokenizer.from_pretrained(model_path)
+        tokenizer = AutoTokenizer.from_pretrained(model_path, use_fast=False)
         model = AutoModelForCausalLM.from_pretrained(model_path, device_map="auto")
         
         progress(0.5, desc="📊 Running baseline benchmark...")


### PR DESCRIPTION
## Summary
- prevent tokenizer conversion errors by loading with `use_fast=False`
- document workaround for SentencePiece/Tiktoken error in README

## Testing
- `python -m py_compile app.py quantize_vlm.py`

------
https://chatgpt.com/codex/tasks/task_e_687922471080832a944a4dc191666411